### PR TITLE
Mistyped attribute name

### DIFF
--- a/lib/openehr/rm/data_types/quantity.rb
+++ b/lib/openehr/rm/data_types/quantity.rb
@@ -13,7 +13,7 @@ module OpenEHR
 
         class DvOrdered < OpenEHR::RM::DataTypes::Basic::DataValue
           include Comparable
-          attr_accessor :normal_range, :other_refference_ranges, :normal_status
+          attr_accessor :normal_range, :other_reference_ranges, :normal_status
 
           def initialize(args = {})
             super(args)


### PR DESCRIPTION
Mistyped attribute name other_reference_ranges in DvOrdered Class.
