### PR TITLE
Should OriginalVersion attestations attribute be mandatory?

### DIFF
--- a/lib/openehr/rm/common/change_control.rb
+++ b/lib/openehr/rm/common/change_control.rb
@@ -140,8 +140,8 @@ module OpenEHR
           end
 
           def attestations=(attestations)
-            if attestations.nil? || attestations.empty?
-              raise ArgumentError, 'attestations is mandatory'
+            if !attestations.nil? && attestations.empty?
+              raise ArgumentError, 'invalid attestations'
             end
             @attestations = attestations
           end

--- a/spec/lib/openehr/rm/common/change_control/original_version_spec.rb
+++ b/spec/lib/openehr/rm/common/change_control/original_version_spec.rb
@@ -57,9 +57,9 @@ describe OriginalVersion do
     @original_version.is_merged?.should be_false
   end
 
-  it 'should raise ArgumentError when attestations is nil' do
+  it 'should raise ArgumentError when attestations is empty' do
     lambda {
-      @original_version.attestations = nil
+      @original_version.attestations = Set.new
     }.should raise_error ArgumentError
   end
 


### PR DESCRIPTION
First of all, thank for your great work!

According to OpenEHR specification 
www.openehr.org/releases/1.0.2/architecture/rm/common_im.pdf
and XML Shemas
https://github.com/openEHR/reference-models/blob/master/models/openEHR/Release-1.0.2/XSD/Version.xsd
attribute attestations in OriginalVersion class is not mandatory. Is there any reason for it to be mandatory?
