### PR TITLE
Change autoload to require

### DIFF
--- a/lib/openehr.rb
+++ b/lib/openehr.rb
@@ -2,9 +2,9 @@ $:.unshift(File.dirname(__FILE__))
 require 'openehr/version'
 
 module OpenEHR
-  autoload :AssumedLibraryTypes, 'openehr/assumed_library_types'
-  autoload :RM, 'openehr/rm'
-  autoload :AM, 'openehr/am'
-  autoload :Parser, 'openehr/parser'
-  autoload :Serializer, 'openehr/serializer'
+  require 'openehr/assumed_library_types'
+  require 'openehr/rm'
+  require 'openehr/am'
+  require 'openehr/parser'
+  require 'openehr/serializer'
 end

--- a/lib/openehr/am.rb
+++ b/lib/openehr/am.rb
@@ -2,7 +2,7 @@ $:.unshift(File.dirname(__FILE__))
 
 module OpenEHR
   module AM
-    autoload :Archetype, 'am/archetype'
-    autoload :OpenEHRProfile, 'am/openehr_profile'
+    require 'am/archetype'
+    require 'am/openehr_profile'
   end
 end

--- a/lib/openehr/am/archetype.rb
+++ b/lib/openehr/am/archetype.rb
@@ -4,9 +4,9 @@ include OpenEHR::RM::Common::Resource
 module OpenEHR
   module AM
     module Archetype
-      autoload :Assertion, 'archetype/assertion'
-      autoload :ConstraintModel, 'archetype/constraint_model'
-      autoload :Ontology, 'archetype/ontology'
+      require 'archetype/assertion'
+      require 'archetype/constraint_model'
+      require 'archetype/ontology'
 
       module ADLDefinition
         CURRENT_ADL_VERSION = "1.4"

--- a/lib/openehr/am/archetype/constraint_model.rb
+++ b/lib/openehr/am/archetype/constraint_model.rb
@@ -4,7 +4,7 @@ module OpenEHR
     module Archetype
       module ConstraintModel
 
-        autoload :Primitive, 'constraint_model/primitive'
+        require 'constraint_model/primitive'
 
         class ArchetypeConstraint
           attr_reader :path

--- a/lib/openehr/am/openehr_profile.rb
+++ b/lib/openehr/am/openehr_profile.rb
@@ -3,7 +3,7 @@ $:.unshift(File.dirname(__FILE__))
 module OpenEHR
   module AM
     module OpenEHRProfile
-      autoload :DataTypes, 'openehr_profile/data_types'
+      require 'openehr_profile/data_types'
     end
   end
 end

--- a/lib/openehr/am/openehr_profile/data_types.rb
+++ b/lib/openehr/am/openehr_profile/data_types.rb
@@ -4,9 +4,9 @@ module OpenEHR
   module AM
     module OpenEHRProfile
       module DataTypes
-        autoload :Text, 'data_types/text'
-        autoload :Quantity, 'data_types/quantity'
-        autoload :Basic, 'data_types/basic'
+        require 'data_types/text'
+        require 'data_types/quantity'
+        require 'data_types/basic'
       end
     end
   end

--- a/lib/openehr/parser.rb
+++ b/lib/openehr/parser.rb
@@ -14,10 +14,10 @@ module OpenEHR
       end
     end
 
-    autoload :ADLParser, 'parser/adl_parser'
-#    autoload :CADLParser, 'parser/adl_parser'
-#    autoload :XMLParser, 'parser/xml_perser'
-#    autoload :Exception, 'parser/exception'
-#    autoload :Scanner, 'parser/scanner'
+    require 'parser/adl_parser'
+#    require 'parser/adl_parser'
+#    require 'parser/xml_perser'
+#    require 'parser/exception'
+#    require 'parser/scanner'
   end
 end

--- a/lib/openehr/rm.rb
+++ b/lib/openehr/rm.rb
@@ -2,15 +2,15 @@ $:.unshift(File.dirname(__FILE__))
 
 module OpenEHR
   module RM
-    autoload :Common, 'rm/common'
-    autoload :Composition, 'rm/composition'
-    autoload :DataStructures, 'rm/data_structures'
-    autoload :DataTypes, 'rm/data_types'
-    autoload :Demographic, 'rm/demographic'
-    autoload :EHR, 'rm/ehr'
-    autoload :Integration, 'rm/integration'
-    autoload :Security, 'rm/security'
-    autoload :Support, 'rm/support'
-    autoload :Factory, 'rm/factory'
+    require 'rm/support'
+    require 'rm/data_types'
+    require 'rm/common'
+    require 'rm/composition'
+    require 'rm/data_structures'
+    require 'rm/demographic'
+    require 'rm/security'
+    require 'rm/ehr'
+    require 'rm/integration'
+    require 'rm/factory'
   end
 end

--- a/lib/openehr/rm/common.rb
+++ b/lib/openehr/rm/common.rb
@@ -4,11 +4,11 @@ $:.unshift(File.dirname(__FILE__)) unless
 module OpenEHR
   module RM
     module Common
-      autoload :Archetyped, 'common/archetyped'
-      autoload :ChangeControl, 'common/change_control'
-      autoload :Directory, 'common/directory'
-      autoload :Generic, 'common/generic.rb'
-      autoload :Resource, 'common/resource'
+      require 'common/archetyped'
+      require 'common/generic'
+      require 'common/change_control'
+      require 'common/directory'
+      require 'common/resource'
     end
   end
 end

--- a/lib/openehr/rm/common/change_control.rb
+++ b/lib/openehr/rm/common/change_control.rb
@@ -2,6 +2,7 @@
 # http://www.openehr.org/uml/release-1.0.1/Browsable/_9_0_76d0249_1109326589721_134411_997Report.html
 # Ticket refs #64
 include OpenEHR::RM::Common::Generic
+
 module OpenEHR
   module RM
     module Common

--- a/lib/openehr/rm/composition.rb
+++ b/lib/openehr/rm/composition.rb
@@ -96,7 +96,7 @@ module OpenEHR
         end
       end
 
-      autoload :Content, 'composition/content'
+      require 'composition/content'
 
     end # end of Composition
   end # end of RM

--- a/lib/openehr/rm/composition/content.rb
+++ b/lib/openehr/rm/composition/content.rb
@@ -10,12 +10,14 @@ module OpenEHR
   module RM
     module Composition
       module Content
-        autoload :Navigation, 'content/navigation'
-        autoload :Entry, 'content/entry'
 
         class ContentItem < Locatable
 
         end
+
+        require 'content/navigation'
+        require 'content/entry'
+
       end # end of Content
     end # end of Composition
   end # end of RM

--- a/lib/openehr/rm/data_structures.rb
+++ b/lib/openehr/rm/data_structures.rb
@@ -8,8 +8,6 @@ $:.unshift(File.dirname(__FILE__)) unless
 module OpenEHR
   module RM
     module DataStructures
-      autoload :ItemStructure, 'data_structures/item_structure'
-      autoload :History, 'data_structures/history'
 
       class DataStructure < OpenEHR::RM::Common::Archetyped::Locatable
         def initialize(args = { })
@@ -20,6 +18,9 @@ module OpenEHR
           raise NotImplementedError, "as_hirarchy must be implemented"
         end
       end
+
+      require 'data_structures/item_structure'
+      require 'data_structures/history'
     end # of Data_Structures
   end # of RM
 end # of OpenEHR

--- a/lib/openehr/rm/data_structures/item_structure.rb
+++ b/lib/openehr/rm/data_structures/item_structure.rb
@@ -11,10 +11,11 @@ module OpenEHR
     module DataStructures
       module ItemStructure
 
-        autoload :Representation, 'item_structure/representation'
+        require 'item_structure/representation'
 
         class ItemStructure < DataStructure
         end
+
 
         class ItemSingle < ItemStructure
           attr_reader :item

--- a/lib/openehr/rm/data_types.rb
+++ b/lib/openehr/rm/data_types.rb
@@ -3,12 +3,13 @@ $:.unshift(File.dirname(__FILE__))
 module OpenEHR
   module RM
     module DataTypes
-      autoload :Basic, 'data_types/basic'
-      autoload :Encapsulated, 'data_types/encapsulated'
-      autoload :Quantity, 'data_types/quantity'
-      autoload :Text, 'data_types/text'
-      autoload :TimeSpecification, 'data_types/time_specification'
-      autoload :URI, 'data_types/uri'
+      require 'data_types/basic'
+      require 'data_types/encapsulated'
+      require 'data_types/quantity'
+      require 'data_types/quantity/date_time'
+      require 'data_types/text'
+      require 'data_types/time_specification'
+      require 'data_types/uri'
     end
   end
 end

--- a/lib/openehr/rm/data_types/quantity.rb
+++ b/lib/openehr/rm/data_types/quantity.rb
@@ -9,7 +9,6 @@ module OpenEHR
   module RM
     module DataTypes
       module Quantity
-        autoload :DateTime, 'quantity/date_time'
 
         class DvOrdered < OpenEHR::RM::DataTypes::Basic::DataValue
           include Comparable

--- a/lib/openehr/rm/data_types/quantity/date_time.rb
+++ b/lib/openehr/rm/data_types/quantity/date_time.rb
@@ -1,9 +1,7 @@
 # This module is implementation of the UML:
 # http://www.openehr.org/uml/release-1.0.1/Browsable/_9_0_76d0249_1109696321450_28117_5362Report.html
 # Ticket refs #49
-require 'openehr/assumed_library_types'
 require 'date'
-require 'openehr/rm/data_types/quantity'
 
 module OpenEHR
   module RM

--- a/lib/openehr/rm/data_types/time_specification.rb
+++ b/lib/openehr/rm/data_types/time_specification.rb
@@ -4,7 +4,7 @@ module OpenEHR
   module RM
     module DataTypes
       module TimeSpecification
-        class DvTimeSpecification < OpenEhr::RM::DataTypes::Basic::DataValue
+        class DvTimeSpecification < OpenEHR::RM::DataTypes::Basic::DataValue
           attr_reader :value
 
           def initialize(value)

--- a/lib/openehr/rm/support.rb
+++ b/lib/openehr/rm/support.rb
@@ -4,10 +4,10 @@ $:.unshift(File.dirname(__FILE__)) unless
 module OpenEHR
   module RM
     module Support
-      autoload :AssumedTypes, 'support/assumed_types'
-      autoload :Definition, 'support/definition'
-      autoload :Identification, 'support/identification'
-      autoload :Measurement, 'support/measurement'
+#      require 'support/assumed_types'
+      require 'support/definition'
+      require 'support/identification'
+      require 'support/measurement'
     end
   end
 end


### PR DESCRIPTION
1. Autoload doesn't properly work. We had several issues when auloading
   didn't load classes in indeterminate way.
2. It's deprecated, and it will be removed
   http://www.ruby-forum.com/topic/3036681