### PR TITLE
fix uninitialized class variable @@schemes in URI

### DIFF
--- a/lib/openehr/rm/data_types/uri.rb
+++ b/lib/openehr/rm/data_types/uri.rb
@@ -24,7 +24,6 @@ module URI
       true
     end
   end
-  @@schemes['EHR'] = EHR
 end
 
 module OpenEHR


### PR DESCRIPTION
Hi, maintainers

When I run rake spec, all specs fail with the following error.
This is my first time with this project, so I don't know the details.
I was able to get all specs to succeed by using the pull request.
Please let me know if there's a way to fix this or if there's anything else I should rewrite.

before

```
An error occurred while loading spec_helper.
Failure/Error: @@schemes['EHR'] = EHR

TypeError:
  no implicit conversion of String into Integer
# ./lib/openehr/rm/data_types/uri.rb:28:in `[]='
# ./lib/openehr/rm/data_types/uri.rb:28:in `<module:URI>'
# ./lib/openehr/rm/data_types/uri.rb:8:in `<top (required)>'
# ./lib/openehr/rm.rb:14:in `require_relative'
# ./lib/openehr/rm.rb:14:in `<top (required)>'
# ./lib/openehr.rb:5:in `require_relative'
# ./lib/openehr.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:10:in `<top (required)>'
No examples found.


Finished in 0.00003 seconds (files took 0.24279 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

after

```
Finished in 30.88 seconds (files took 4.44 seconds to load)
2938 examples, 0 failures, 14 pending
```