### PR TITLE
CI: bump actions/checkout to v7 (clears Node 20 deprecation warning)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         ruby: ['3.3', '3.4', '4.0']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -27,7 +27,7 @@ jobs:
     name: RuboCop
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -26,6 +26,16 @@ now also stale — `openehr-rails`'s `master` has both `.github/workflows/ci.yml
 (confirmed via `gh run list` in that repo). Actual run-by-run verification of that CI is
 being tracked in `openehr-rails`'s own `docs/backlog.md`, not duplicated here.
 
+**Action version bump (2026-08-23)**: `actions/checkout` bumped `v4` → `v7` in
+`.github/workflows/ci.yml` (PR #42) to clear a "Node.js 20 is deprecated" warning that
+every job in PR #41's run (`32610536000`) logged. Confirmed fixed, not just green, on
+PR #42's own run `32610802034` — `grep -ci` across its full log for the warning text
+returns 0. `ruby/setup-ruby@v1` was left unchanged; its `action.yml` already declares
+`using: node24`, matching the fact that it was never named in the warning. `openehr-rails`
+likely has the same class of warning in its own `ci.yml`/`release.yml` — not checked here;
+that repo's own session owns verifying and fixing its own workflow files (repository
+boundary rule, `CLAUDE.md`), not duplicated in this repo's tracking.
+
 ## From #6a investigation (C_CODE_REFERENCE parse crash, 2026-08-22)
 
 - **Parser error-handling asymmetry (`XMLArchetypeParser` vs `OPTParser`)**: while


### PR DESCRIPTION
## Summary

Every job in the most recent CI run before this PR (PR #41's run [`32610536000`](https://github.com/skoba/openehr-ruby/actions/runs/32610536000)) logged the same GitHub Actions warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4.

## Before / After

| Action | Before | After | Node runtime confirmed via |
|---|---|---|---|
| `actions/checkout` | `v4` | `v7` (currently resolves to `v7.0.1`) | `action.yml` at ref `v7.0.1`: `using: node24` |
| `ruby/setup-ruby` | `v1` | `v1` (unchanged) | `action.yml` at ref `v1`: `using: node24` (already current; was never flagged in the run log) |

Both confirmed by fetching each action's `action.yml` directly (`gh api repos/<owner>/<repo>/contents/action.yml?ref=<tag>`), not inferred from version numbers.

## Verification

- [x] CI on this PR: all 4 jobs green - run [`32610802034`](https://github.com/skoba/openehr-ruby/actions/runs/32610802034).
- [x] Warning confirmed gone: `grep -ci` across that run's full log for "node.*20", "node.js.*deprecat", and "forced to run" all return 0 matches. Green status alone was not treated as sufficient.

## Compatibility / semver

CI-config-only change; doesn't touch shipped runtime code (`lib/`), the gemspec, or `required_ruby_version`. Semver: **neutral** - same classification as `e728023` (CLAUDE.md's Release convention worked example for a dev-tooling/CI change).

## Follow-up (not in this PR)

`openehr-rails`'s CI config is a separate workflow file in a separate repo - checking it for the same warning is that repo's own session's responsibility, not duplicated here (per this repo's repository-boundary rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)