### PR TITLE
Fix: RMJSONSerializer's seen-guard misidentified aliasing as a cycle

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -19,6 +19,19 @@ diff accumulated since 2.4.0 (per this file's own Release convention).
   message assertion, specifically to pin the *unchanged* (non-alias)
   case. A downstream caller matching this gem's error text by exact
   string equality is the only audience this note is for.
+* RMJSONSerializer's cycle guard now only treats an object as "seen"
+  while it's actively being recursed into (pushed on entry, popped on
+  exit) rather than permanently once first encountered. Two different
+  attributes on the same object that alias the same sub-object (e.g.
+  OperationalTemplate#template_id=, which sets both template_id and
+  archetype_id to the identical object) now both serialize that
+  sub-object's real value; previously the second occurrence silently
+  serialized as null. Genuine cycles (e.g. PATHABLE's @parent, already
+  excluded from traversal separately) are still caught correctly -
+  this only narrows what counts as "seen", it does not remove the
+  guard. Observable change: any output containing a previously-nulled
+  aliased attribute will now contain that attribute's real value
+  instead. (#40)
 
 === 2.4.0
 Bug fix release: RMJSONSerializer <-> CompositionFactory.create_from_json

--- a/docs/design/fix-seen-guard-aliasing-plan.md
+++ b/docs/design/fix-seen-guard-aliasing-plan.md
@@ -1,0 +1,209 @@
+# Plan: RMJSONSerializer's seen-guard misidentifies aliasing as cycles (#40)
+
+## Context
+
+[#40](https://github.com/skoba/openehr-ruby/issues/40): `RMJSONSerializer`'s
+`seen` guard (`lib/openehr/serializer/rm_json_serializer.rb`) permanently
+marks an object as "seen" the first time it's encountered and never
+un-marks it. This correctly stops a true cycle, but also fires for
+non-cyclic **aliasing** — two different attributes on the same object
+pointing at the *identical* sub-object — silently emitting `null` for the
+second occurrence instead of the sub-object's real value.
+
+## Explore results (verified against master @ `00c394d`)
+
+### (a) Cycle inventory: what remains after `@parent` exclusion?
+
+Both genuine back-reference families in the codebase are named `@parent`,
+and both are already fully covered by `EXCLUDED_IVARS`'s single `:@parent`
+entry (exclusion is by ivar symbol, not by class):
+
+- **RM side** (`PATHABLE`): `Pathable` (`lib/openehr/rm/common/archetyped.rb:21-22`)
+  declares `attr_accessor :parent`; `Locatable < Pathable` (`:151`) inherits
+  it. Actively built by `Composition#content=` (`composition.rb:61`),
+  `History#events=` (`data_structures/history.rb:41`),
+  `Cluster#items=` (`data_structures/item_structure/representation.rb:71`),
+  and `Pathable#initialize` for any directly-`Pathable` class given a
+  `:parent` arg. Genuinely dereferenced at runtime, not inert:
+  `Event#offset` reads `@parent.origin` (`history.rb:73`).
+- **AOM side** (`ArchetypeConstraint`): independently declares its own
+  `attr_accessor :parent` (`am/archetype/constraint_model.rb:5-11`,
+  `initialize` sets it from `args[:parent]`), built by
+  `CAttribute#children=` (`:200-202`) and `CComplexObject#attributes=`
+  (`:296-298`). Also dereferenced at runtime (`congruent?`'s
+  `path.index(@parent.path)`, `:26`).
+- A broad search (`@owner`, `@container`, `@composition`, any `= self`
+  assignment) across all of `lib/openehr/` found **no other back-reference
+  ivar family** anywhere. (One coincidental, irrelevant hit:
+  `OpenEHR::AQL::Model::Containment` also has an ivar literally named
+  `@parent`, but no RM/AOM class ever holds a `Containment` instance, so
+  it's unreachable from anything `RMJSONSerializer` is asked to serialize.)
+
+**Implication**: there is currently **no genuine, reachable cycle** in the
+RM/AOM object graph — both families that could form one are already
+excluded. A stack-based guard's true-cycle-catching behavior therefore
+cannot be exercised against any *real* class today; it would be
+defense-in-depth for a case that isn't presently live, not a fix for an
+observable gap. **Cycle 2 below must use a synthetic object graph** — no
+real artifact can demonstrate a currently-reachable cycle (four-kind
+fixture taxonomy: synthetic, design authority = this plan's finding (a)).
+
+### (b) Other aliasing cases beyond `ObjectVersionID`
+
+- `ObjectVersionID#value=` (`lib/openehr/rm/support/identification.rb:247-258`)
+  still sets `@root = @oid` internally (line 253) — **#32 did not remove the
+  aliasing**, it only added `@root`/`@oid`/etc. to `EXCLUDED_IVARS`
+  (`rm_json_serializer.rb:26-27`), which masks the *symptom* from JSON
+  output without touching the underlying object identity. Not currently
+  observable via `RMJSONSerializer` — matches #40's own prior note.
+- **New finding, independently reproduced twice** (once via exploration,
+  once directly, below): `OperationalTemplate#template_id=`
+  (`lib/openehr/am/template.rb:31-38`) sets **both** `@template_id` and
+  `@archetype_id` to the identical passed-in object:
+
+  ```ruby
+  def template_id=(template_id)
+    if template_id.nil?
+      raise ArgumentError, 'template_id is mandatory for operational template'
+    end
+    @template_id = template_id
+    # Update archetype_id to match template_id for consistency
+    @archetype_id = template_id if template_id
+  end
+  ```
+
+  Neither `@template_id` nor `@archetype_id` is in `EXCLUDED_IVARS` — this
+  case is **not masked**, and is reproducible today:
+
+  ```
+  $ bundle exec ruby -e '
+  require "openehr"
+  template_id = OpenEHR::RM::Support::Identification::TemplateID.new(value: "1234567890")
+  opt = OpenEHR::AM::Template::OperationalTemplate.allocate
+  opt.send(:template_id=, template_id)
+  puts "template_id.equal?(archetype_id): #{opt.template_id.equal?(opt.archetype_id)}"
+  seen = Set.new.compare_by_identity
+  serializer = OpenEHR::Serializer::RMJSONSerializer.new(opt)
+  puts serializer.send(:object_value, opt.template_id, seen).inspect
+  puts serializer.send(:object_value, opt.archetype_id, seen).inspect
+  '
+  template_id.equal?(archetype_id): true
+  {"_type"=>"TEMPLATE_ID", "value"=>"1234567890"}
+  nil
+  ```
+
+**Implication — changes #40's own prior assumption**: #40's issue body
+says the "Suggested test" needs "a synthetic two-attributes-alias-one-object
+fixture as its primary path, not a fallback to one," written when
+`ObjectVersionID` was the only known case and #32 was about to exclude it.
+That's now stale: `OperationalTemplate` is a real, already-shipped,
+already-tested RM/AM class that reproduces this bug today, unmasked. Per
+this repo's fixture taxonomy ("real/reduced are preferred by default;
+synthetic is only for structural test cases whose reproduction conditions
+can't be controlled with a real artifact") — **recommending `OperationalTemplate`
+as Cycle 0's real reproduction case instead of a synthetic double-reference
+fixture.** Flagged as the one substantive decision point for gate approval
+below; a synthetic fixture is only needed for Cycle 2 (the true-cycle
+regression pin), not for Cycle 0.
+
+### (c) Impact scope of the in-progress-stack fix
+
+Proposed mechanism: `object_value` pushes `value` into `seen` before
+recursing (as today), then **pops it** (`seen.delete(value)`) right before
+returning the built hash — narrowing `seen`'s meaning from "ever
+encountered" to "currently being recursed into." The existing `return nil
+if seen.include?(value)` check is unchanged, so true-cycle behavior
+(returns `nil` for the cyclic back-reference) is preserved exactly.
+
+Verified in isolation (a standalone script, not touching real source — see
+this plan's git history / session transcript for the exact script) against
+both target behaviors:
+
+- **Aliasing** (two parents, one shared child): both occurrences serialize
+  the child's real value — the child is popped after the first occurrence
+  finishes, so it's no longer "seen" by the time the second is reached.
+- **True cycle** (A → B → A): still correctly caught at the innermost
+  level — A is still in `seen` (not yet popped, since we're still inside
+  its own recursion) when B's reference back to A is reached. No
+  `SystemStackError`, no infinite loop.
+
+**Existing-spec risk, checked**: `rm_json_serializer_spec.rb`'s "excludes
+the parent back-reference, avoiding infinite recursion" example
+(`:92-99`) does **not** exercise the `seen` guard's cycle-catching behavior
+at all — `@parent` is filtered out of `instance_variables` by
+`EXCLUDED_IVARS` before any recursion into it happens, so this spec passes
+purely via exclusion, never reaching the `seen.include?` check for that
+link. Confirms (again, independently of finding (a)) that no existing spec
+provides real coverage of the guard's cycle-catching behavior — which is
+exactly why Cycle 2 below has to be new and synthetic, not a
+straightforward "make sure the existing spec stays green" check.
+
+## Decision
+
+Implement the push-on-enter/pop-on-exit shape in `object_value`. No change
+to `EXCLUDED_IVARS` — `OperationalTemplate`'s aliasing being *observable*
+(not masked) is what makes it usable as Cycle 0's red spec; excluding it
+would defeat that.
+
+## TDD cycles (t-wada; issue #40 is labeled `bug` → resolution shape (a),
+red-first, per this repo's Ticket-driven workflow)
+
+1. **Cycle 1 (regression pin, written first — safety net before touching
+   the mechanism)**: a synthetic two-node object graph with a genuine
+   mutual back-reference (A ↔ B), asserting serialization completes
+   without raising and without exceeding a bounded recursion depth, and
+   that the cyclic link itself resolves to `nil` (matching today's
+   behavior). This is **already green today** (current code already
+   handles true cycles correctly — that was never the bug) — per the
+   Ticket-driven workflow's resolution-shape rule, this must be written and
+   labeled **"regression pin"** in a spec comment, not staged as fake red.
+   Confirms the fix doesn't reintroduce infinite recursion before Cycle 2
+   makes any change.
+2. **Cycle 2 (red)**: `OperationalTemplate` built with a real `TemplateID`,
+   serialized via `RMJSONSerializer`; asserts `archetype_id`'s serialized
+   value is *not* `null` and matches `template_id`'s own serialized value.
+   Red today (confirmed above — `archetype_id` currently serializes to
+   `null`).
+3. **Cycle 3 (green, minimal)**: implement the push/pop change in
+   `object_value`. Confirm Cycle 2 goes green and Cycle 1 stays green.
+4. **Cycle 4 (regression)**: full `bundle exec rspec` run — particularly
+   `rm_json_serializer_spec.rb`'s existing round-trip and `@parent`-exclusion
+   examples, and anything exercising `OpenEHR::AQL::ResultSet`/`opt_serializer.rb`
+   (both call `RMJSONSerializer`/`JSONSerializer` directly, per the earlier
+   cycle-inventory sweep).
+5. **Cycle 5 (refactor)**: none anticipated beyond Cycles 1-4; the change
+   is small and self-contained.
+
+## Compatibility note (History.txt draft, added at merge time per this
+repo's own convention)
+
+```
+* RMJSONSerializer's cycle guard now only treats an object as "seen"
+  while it's actively being recursed into (pushed on entry, popped on
+  exit) rather than permanently once first encountered. Two different
+  attributes on the same object that alias the same sub-object (e.g.
+  OperationalTemplate#template_id=, which sets both template_id and
+  archetype_id to the identical object) now both serialize that
+  sub-object's real value; previously the second occurrence silently
+  serialized as null. Genuine cycles (e.g. PATHABLE's @parent, already
+  excluded from traversal separately) are still caught correctly - this
+  only narrows what counts as "seen", it does not remove the guard.
+  Observable change: any output containing a previously-nulled aliased
+  attribute will now contain that attribute's real value instead. (#40)
+```
+
+## Acceptance criteria mapping (from #40)
+
+- "A spec exists asserting that when two attributes... reference an
+  identical sub-object..., `RMJSONSerializer` serializes both attributes
+  with the sub-object's real value, not `null`." → Cycle 2.
+- "Existing cycle-guard behavior... remains covered by a regression spec
+  and stays green." → Cycle 1 (written first, explicitly as a regression
+  pin) + Cycle 4's full-suite check.
+
+## Open question for gate approval
+
+Use `OperationalTemplate` (real, already-shipped class) as Cycle 2's
+reproduction case instead of the synthetic fixture #40's own issue body
+assumed would be needed? Recommended yes, per the reasoning in finding (b)
+above and this repo's real-preferred fixture taxonomy.

--- a/docs/design/fix-seen-guard-aliasing-plan.md
+++ b/docs/design/fix-seen-guard-aliasing-plan.md
@@ -44,9 +44,13 @@ RM/AOM object graph — both families that could form one are already
 excluded. A stack-based guard's true-cycle-catching behavior therefore
 cannot be exercised against any *real* class today; it would be
 defense-in-depth for a case that isn't presently live, not a fix for an
-observable gap. **Cycle 2 below must use a synthetic object graph** — no
-real artifact can demonstrate a currently-reachable cycle (four-kind
-fixture taxonomy: synthetic, design authority = this plan's finding (a)).
+observable gap. **Cycle 1 below builds its own minimal cyclic object graph
+inline in the spec** — no real artifact can demonstrate a currently-reachable
+cycle. This is a plain Ruby object pair wired directly in the spec body, not
+a fixture file, so it falls **outside** the four-kind fixture taxonomy (that
+classification, and its leading-comment requirement, applies to fixture
+*files* under `spec/fixtures/`-style paths — an inline test double built and
+discarded within one spec has no such file, and needs no kind label).
 
 ### (b) Other aliasing cases beyond `ObjectVersionID`
 
@@ -101,10 +105,11 @@ already-tested RM/AM class that reproduces this bug today, unmasked. Per
 this repo's fixture taxonomy ("real/reduced are preferred by default;
 synthetic is only for structural test cases whose reproduction conditions
 can't be controlled with a real artifact") — **recommending `OperationalTemplate`
-as Cycle 0's real reproduction case instead of a synthetic double-reference
+as Cycle 2's real reproduction case instead of a synthetic double-reference
 fixture.** Flagged as the one substantive decision point for gate approval
-below; a synthetic fixture is only needed for Cycle 2 (the true-cycle
-regression pin), not for Cycle 0.
+below; a synthetic (inline, not a fixture file — see finding (a)) object
+graph is only needed for Cycle 1 (the true-cycle regression pin), not for
+Cycle 2.
 
 ### (c) Impact scope of the in-progress-stack fix
 
@@ -135,14 +140,15 @@ at all — `@parent` is filtered out of `instance_variables` by
 purely via exclusion, never reaching the `seen.include?` check for that
 link. Confirms (again, independently of finding (a)) that no existing spec
 provides real coverage of the guard's cycle-catching behavior — which is
-exactly why Cycle 2 below has to be new and synthetic, not a
-straightforward "make sure the existing spec stays green" check.
+exactly why Cycle 1 below has to be new (though not red — see its own
+entry), not a straightforward "make sure the existing spec stays green"
+check.
 
 ## Decision
 
 Implement the push-on-enter/pop-on-exit shape in `object_value`. No change
 to `EXCLUDED_IVARS` — `OperationalTemplate`'s aliasing being *observable*
-(not masked) is what makes it usable as Cycle 0's red spec; excluding it
+(not masked) is what makes it usable as Cycle 2's red spec; excluding it
 would defeat that.
 
 ## TDD cycles (t-wada; issue #40 is labeled `bug` → resolution shape (a),

--- a/lib/openehr/serializer/rm_json_serializer.rb
+++ b/lib/openehr/serializer/rm_json_serializer.rb
@@ -61,6 +61,7 @@ module OpenEHR
 
           hash[ivar.to_s.delete_prefix('@')] = to_value(field, seen)
         end
+        seen.delete(value)
         hash
       end
     end

--- a/spec/lib/openehr/serializer/rm_json_serializer_spec.rb
+++ b/spec/lib/openehr/serializer/rm_json_serializer_spec.rb
@@ -9,6 +9,34 @@ include OpenEHR::AM::Archetype::ConstraintModel
 include OpenEHR::AssumedLibraryTypes
 
 describe RMJSONSerializer do
+  it 'serializes a genuine mutual back-reference without recursing forever' do
+    first = Object.new
+    second = Object.new
+    first.instance_variable_set(:@other, second)
+    second.instance_variable_set(:@other, first)
+
+    result = nil
+    expect { result = JSON.parse(RMJSONSerializer.new(first).serialize) }.not_to raise_error
+    # regression pin: true cycles resolve to nil at the cyclic link.
+    expect(result.dig('other', 'other')).to be_nil
+  end
+
+  # Resolution shape (a), bug: the aliased archetype_id reproduced null before the fix.
+  it 'serializes both identifiers aliased by an operational template' do
+    template_id = OpenEHR::RM::Support::Identification::TemplateID.new(value: 'example.template.v1')
+    template = OpenEHR::AM::Template::OperationalTemplate.new(
+      template_id: template_id,
+      original_language: Object.new,
+      description: Object.new,
+      definition: Object.new,
+      ontology: Object.new
+    )
+
+    result = JSON.parse(RMJSONSerializer.new(template).serialize)
+    expect(result['archetype_id']).not_to be_nil
+    expect(result['archetype_id']).to eq(result['template_id'])
+  end
+
   it 'round-trips the health summary composition through canonical JSON' do
     json = File.read(File.expand_path('../../../fixtures/health_summary_composition.json', __dir__))
     composition = OpenEHR::RM::CompositionFactory.create_from_json(json)


### PR DESCRIPTION
## Summary

Fixes #40: `RMJSONSerializer`'s `seen` guard (`lib/openehr/serializer/rm_json_serializer.rb`) permanently marked an object as "seen" the first time it was encountered and never un-marked it. This correctly stopped a true cycle, but also fired for non-cyclic **aliasing** - two different attributes on the same object pointing at the *identical* sub-object - silently emitting `null` for the second occurrence.

Full explore + design rationale: `docs/design/fix-seen-guard-aliasing-plan.md`.

## Fix

`object_value` now pops the value (`seen.delete(value)`) right before returning the built hash, in addition to the existing push - `seen` now means "currently being recursed into," not "ever encountered." The existing `return nil if seen.include?(value)` check for a genuine cycle is unchanged.

## Explore highlights (see plan doc for full citations)

- No genuine, currently-reachable cycle exists in the RM/AOM graph beyond the already-excluded `@parent` (both its `PATHABLE` and `ArchetypeConstraint` instances) - confirmed by a full sweep of `lib/openehr/rm/` and `lib/openehr/am/`.
- `ObjectVersionID`'s `@root = @oid` aliasing (the bug's original trigger) is still present internally but masked by #32's output exclusion.
- **New finding**: `OperationalTemplate#template_id=` (`lib/openehr/am/template.rb:31-38`) aliases `@template_id`/`@archetype_id` to the identical object, unmasked - a real, already-shipped reproduction case, preferred over a synthetic fixture per this repo's real-artifact-first taxonomy. Commented on #40 with the empirical detail.

## Tests (resolution shape: bug, per Ticket-driven workflow)

- **Regression pin** (inline synthetic A↔B pair, not a fixture file - outside the four-kind fixture taxonomy): a genuine cycle still resolves to `nil` without infinite recursion. Already green before this fix; written first as a safety net, explicitly commented "regression pin" per this repo's rule against staging fake-red for an already-true property.
- **Red → green**: a real `OperationalTemplate` serialized via `RMJSONSerializer` - `archetype_id` was `nil` before the fix, now matches `template_id`'s real serialized value.

## Compatibility

`History.txt` entry added now (merge time, per this repo's "code-change entries land at merge time" rule) - any output containing a previously-nulled aliased attribute will now contain that attribute's real value instead.

## Related

- Fixes #40
- Related: #43 (found while exploring this fix - `Archetype#physical_paths` drops an embedded `C_ARCHETYPE_ROOT`'s own node_id bracket; unrelated bug, filed separately)

## Test plan
- [x] `bundle exec rspec spec/lib/openehr/serializer/rm_json_serializer_spec.rb` - 11 examples, 0 failures
- [x] Full `bundle exec rspec` - 3970 examples, 0 failures
- [x] `bundle exec rubocop` (touched files) - no offenses

## Release

Semver: patch (touches `lib/openehr/serializer/rm_json_serializer.rb`). Batches with #38 in the unreleased 2.4.1 section of `History.txt`; final version number confirmed at tag time.

Implemented-by: Codex

🤖 Generated with [Claude Code](https://claude.com/claude-code)