### PR TITLE
Fix: ArchetypeID/TerminologyID dropped their canonical value from JSON

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,22 @@
+=== 2.4.2 (unreleased)
+Version number is a placeholder, finalized at tag time from the actual
+diff accumulated since 2.4.1 (per this file's own Release convention).
+
+* RMJSONSerializer now emits the canonical "value" key for ArchetypeID
+  and TerminologyID (both OBJECT_ID subtypes) instead of only their
+  internal decomposed fields (rm_originator/rm_name/rm_entity/
+  concept_name/specialisation/version_id for ArchetypeID; name/
+  version_id for TerminologyID) - the same class of gap #32 fixed for
+  ObjectVersionID, generalized to these two sibling types. The
+  exclusion is scoped to these two classes specifically (not a global
+  ivar exclusion), so unrelated classes with their own :@name or
+  :@version_id ivars (e.g. any Locatable's #name, or
+  RevisionHistoryItem#version_id) are unaffected. Reading back JSON
+  persisted by a prior version of this gem (decomposed keys only, no
+  "value") is unaffected - Factory already reconstructs both types
+  from their individual fields when "value" is absent. (#46, first
+  reported as #45)
+
 === 2.4.1
 Diagnostics and correctness release: AQL WHERE-clause alias-collision
 errors get a clearer hint, and RMJSONSerializer no longer treats

--- a/docs/design/fix-archetype-terminology-id-value-plan.md
+++ b/docs/design/fix-archetype-terminology-id-value-plan.md
@@ -86,17 +86,35 @@ path never consults `EXCLUDED_IVARS`. Matches the task's own expectation
 
 ## Decision
 
-Mirror #32/PR #39's `ObjectVersionID` pattern exactly, for both classes:
+Mirror #32/PR #39's `ObjectVersionID` pattern for the setters, but **not**
+for the exclusion mechanism:
 
 1. `ArchetypeID#value=` and `TerminologyID#value=` each add `@value = value`
    (storing the canonical string directly; the decomposition stays, since
    `qualified_rm_entity`/`domain_concept`/etc. still need the individual
    fields for their own logic).
-2. Add to `RMJSONSerializer::EXCLUDED_IVARS`: `ArchetypeID`'s
-   `:@rm_originator, :@rm_name, :@rm_entity, :@concept_name,
-   :@specialisation, :@version_id` and `TerminologyID`'s `:@name` (note:
-   `:@version_id` is shared by name with `ArchetypeID`'s own decomposed
-   ivar — one entry covers both, they're the same symbol).
+2. **Correction, found during implementation (not by this plan's original
+   explore)**: a flat, global `RMJSONSerializer::EXCLUDED_IVARS` addition
+   (this plan's original wording) is **unsafe** for `:@name` and
+   `:@version_id` specifically — unlike `ObjectVersionID`'s exclusions
+   (`@root`/`@oid`/etc., which are effectively unique to that class), both
+   symbols collide with genuinely unrelated, legitimate ivars elsewhere:
+   `:@name` is `Locatable#name` (a `DvText`, present on nearly every RM
+   class — `Cluster`, `Element`, `Composition`, ...) via
+   `lib/openehr/rm/common/archetyped.rb:177`, and `:@version_id` is
+   `RevisionHistoryItem#version_id` (`lib/openehr/rm/common/generic.rb:85`).
+   Globally excluding either would have silently dropped those fields from
+   every affected class's serialized output — a real regression, verified
+   both by the implementer (full suite failed under the naive approach) and
+   independently by me (`Cluster#name` dropped to `null` under a manual
+   test of the naive global-exclusion shape). **Fixed shape**: exclusion is
+   now **class-conditional** — `object_value` calls a new
+   `excluded_ivars(value)` method that starts from `EXCLUDED_IVARS` minus
+   the identifier-specific symbols, then adds `ArchetypeID`'s six ivars back
+   only when `value.is_a?(ArchetypeID)`, or `TerminologyID`'s two only when
+   `value.is_a?(TerminologyID)`. Verified independently (`Cluster#name`
+   preserved; `ArchetypeID`/`TerminologyID` still correctly `{_type,
+   value}`-only).
 3. New watchdog spec(s): each identifier class's JSON `value` key
    round-trips, structurally closing off a fourth recurrence in any other
    `ObjectID` subtype the same way #32 intended but didn't generalize.
@@ -132,10 +150,14 @@ workflow)
   internal decomposed fields (rm_originator/rm_name/rm_entity/
   concept_name/specialisation/version_id for ArchetypeID; name/
   version_id for TerminologyID) - the same class of gap #32 fixed for
-  ObjectVersionID, generalized to these two sibling types. Reading back
-  JSON persisted by a prior version of this gem (decomposed keys only,
-  no "value") is unaffected - Factory already reconstructs both types
-  from their individual fields when "value" is absent. (#46)
+  ObjectVersionID, generalized to these two sibling types. The exclusion
+  is scoped to these two classes specifically (not a global ivar
+  exclusion), so unrelated classes with their own :@name or
+  :@version_id ivars (e.g. any Locatable's #name, or
+  RevisionHistoryItem#version_id) are unaffected. Reading back JSON
+  persisted by a prior version of this gem (decomposed keys only, no
+  "value") is unaffected - Factory already reconstructs both types from
+  their individual fields when "value" is absent. (#46)
 ```
 
 ## Acceptance criteria mapping (from the filed issue)

--- a/docs/design/fix-archetype-terminology-id-value-plan.md
+++ b/docs/design/fix-archetype-terminology-id-value-plan.md
@@ -1,0 +1,155 @@
+# Plan: ArchetypeID/TerminologyID drop their canonical `value` from JSON (#46, #32 pathology, 3rd instance)
+
+## Context
+
+[#46](https://github.com/skoba/openehr-ruby/issues/46): anlage found
+(`issue9-log` R2, blocking `skoba/anlage#9`) that `ArchetypeID` and
+`TerminologyID` never emit a `value` key when serialized via
+`RMJSONSerializer`, even on openehr 2.4.1 (confirmed after bumping — not a
+stale pre-2.4.1 report). This is the same root-cause *shape* as #32's
+`ObjectVersionID` bug (fixed by PR #39), just in two sibling `ObjectID`
+subtypes #32 didn't check at the time.
+
+## Explore results (verified against master @ `59f5948`)
+
+### (1) Compared against PR #39's `ObjectVersionID` fix pattern
+
+`ObjectID#value=` (`identification.rb:15-18`) sets `@value = value` in the
+base class. `ArchetypeID#value=` (`:70-81`) and `TerminologyID#value=`
+(`:172-181`) both **override without calling `super`**, decomposing into
+component ivars instead — exactly `ObjectVersionID`'s pre-#39 shape. Their
+`value` getters (`ArchetypeID#value` `:95-98`, `TerminologyID#value`
+`:163-169`) are **computed** (not `attr_reader`), so the Ruby-level
+`.value` call still works correctly — only the *serialized JSON* is
+missing the key, since `RMJSONSerializer` reflects on `instance_variables`
+directly, not method calls.
+
+### (2) Exhaustive sweep of the same pathology
+
+`grep -rln 'def value=' lib/openehr/rm/ lib/openehr/am/` found 11 files;
+every `value=` implementation was read. Result: **`ArchetypeID` and
+`TerminologyID` are the only two classes** with this exact pathology
+(computed getter + non-`super`, non-`@value`-storing setter). Everything
+else already sets `@value` directly or via `super`: `UID`/`UIDBasedID`/
+`ObjectVersionID`, `DvDate`/`DvTime`/`DvDateTime`/`DvDuration` (already
+covered by #32's `EXCLUDED_IVARS`), `DvText`, `DvUri`/`DvEhrUri`,
+`DvOrdinal`/`DvScale`, `Timezone`, `ValidityKind`, `OperatorKind`,
+`CDvState`, `DvTimeSpecification` and its subclasses.
+
+**`VersionTreeID`/`KNOWN_DERIVED_CACHE_TYPES` relationship, clarified**:
+`VersionTreeID#value=` (`:343-349`) has a related-but-different quirk — its
+getter (`:351-356`) reassigns `@value` as a side effect on every call (not
+real memoization), so `@value` may or may not be present depending on
+unrelated call history. This is **out of scope** here: nothing canonically
+needs a `value` key from `VersionTreeID`'s own JSON shape (consumers use
+`trunk_version`/`branch_number`/`branch_version` directly — even
+`ObjectVersionID#value` itself interpolates `@version_tree_id.value` in
+Ruby code, never reads it from JSON), and if `@value` *does* leak into
+output, `KNOWN_DERIVED_CACHE_TYPES` (`factory.rb:23`) already tolerates an
+unrecognized `value` key for `VERSION_TREE_ID` on read. `ArchetypeID`/
+`TerminologyID` have the opposite problem — a *missing*, not
+possibly-redundant, key — and neither needs adding to
+`KNOWN_DERIVED_CACHE_TYPES`: both already have working `Factory` classes
+(`ArchetypeIdFactory`, `TerminologyIdFactory`, `factory.rb:329-345`), so
+there's no `NameError` for that mechanism to catch. This fix is purely
+about what gets *written*.
+
+### (3) Watchdog gap, confirmed
+
+`spec/lib/openehr/rm/support/identification/archetype_id_spec.rb`
+extensively asserts the Ruby-level `.value` getter (which round-trips
+correctly regardless of this bug, since it's computed from ivars either
+way) but never serializes through `RMJSONSerializer`. `factory_spec.rb`'s
+`ArchetypeID` examples only assert `be_an_instance_of(ArchetypeID)` —
+existence, not a JSON value round-trip. Same gap class #32 closed for
+`ObjectVersionID` specifically, not generalized to sibling types.
+
+### (4) Compatibility: old-JSON read-back, verified empirically
+
+```
+$ bundle exec ruby -e '...'
+Ruby-level .value: "openEHR-EHR-SECTION.physical_examination.v2"
+Serialized JSON: {"_type":"ARCHETYPE_ID","rm_originator":"openEHR",...}  # no "value" key (today's output)
+value key present? false
+Restored via decomposed-keys JSON, .value: "openEHR-EHR-SECTION.physical_examination.v2"
+```
+
+Reading today's (decomposed-only) JSON back through `Factory.create`
+already reconstructs `.value` correctly — `ArchetypeID#initialize`/
+`TerminologyID#initialize` branch on `args[:value].nil?` and fall back to
+individual setters. New-shape (`value`-only) JSON already works too, since
+that's how these objects are normally built (`Factory.create('ARCHETYPE_ID',
+value: ...)` → `super(args)` → base `value=`). **Both directions are
+unaffected by this fix** — it changes only what's written; `Factory`'s read
+path never consults `EXCLUDED_IVARS`. Matches the task's own expectation
+("スカラー無視の既存挙動で現状維持のはず").
+
+## Decision
+
+Mirror #32/PR #39's `ObjectVersionID` pattern exactly, for both classes:
+
+1. `ArchetypeID#value=` and `TerminologyID#value=` each add `@value = value`
+   (storing the canonical string directly; the decomposition stays, since
+   `qualified_rm_entity`/`domain_concept`/etc. still need the individual
+   fields for their own logic).
+2. Add to `RMJSONSerializer::EXCLUDED_IVARS`: `ArchetypeID`'s
+   `:@rm_originator, :@rm_name, :@rm_entity, :@concept_name,
+   :@specialisation, :@version_id` and `TerminologyID`'s `:@name` (note:
+   `:@version_id` is shared by name with `ArchetypeID`'s own decomposed
+   ivar — one entry covers both, they're the same symbol).
+3. New watchdog spec(s): each identifier class's JSON `value` key
+   round-trips, structurally closing off a fourth recurrence in any other
+   `ObjectID` subtype the same way #32 intended but didn't generalize.
+
+## TDD cycles (t-wada; resolution shape: bug, red-first, per Ticket-driven
+workflow)
+
+1. **Cycle 1 (red)**: a spec serializing `ArchetypeID.new(value: ...)` and
+   `TerminologyID.new(value: ...)` via `RMJSONSerializer`, asserting the
+   parsed JSON's `"value"` key equals the original string, for both.
+   Confirmed red today (both currently omit the key).
+2. **Cycle 2 (green, minimal)**: implement the Decision above for both
+   classes. Confirm Cycle 1 goes green.
+3. **Cycle 3 (regression pin — already true, not staged as fake-red)**: a
+   spec confirming both old-shape (decomposed-keys-only) and new-shape
+   (`value`-only) JSON read back correctly via `Factory.create` for both
+   `ArchetypeID` and `TerminologyID` — four assertions. This property is
+   **already true before this fix** (verified in finding (4)), so per this
+   repo's Ticket-driven workflow rule it must be written and labeled
+   "regression pin" in a spec comment, not staged as red-first.
+4. **Cycle 4 (regression)**: full `bundle exec rspec` run, particularly
+   `archetype_id_spec.rb`, `factory_spec.rb`'s `ArchetypeIdFactory`/
+   `TerminologyIdFactory` examples, and anything serializing an
+   `Archetyped`/ontology object that embeds either identifier type.
+5. **Cycle 5 (refactor)**: none anticipated; the change mirrors an
+   already-established pattern exactly.
+
+## Compatibility note (History.txt draft, added at merge time)
+
+```
+* RMJSONSerializer now emits the canonical "value" key for ArchetypeID
+  and TerminologyID (both OBJECT_ID subtypes) instead of only their
+  internal decomposed fields (rm_originator/rm_name/rm_entity/
+  concept_name/specialisation/version_id for ArchetypeID; name/
+  version_id for TerminologyID) - the same class of gap #32 fixed for
+  ObjectVersionID, generalized to these two sibling types. Reading back
+  JSON persisted by a prior version of this gem (decomposed keys only,
+  no "value") is unaffected - Factory already reconstructs both types
+  from their individual fields when "value" is absent. (#46)
+```
+
+## Acceptance criteria mapping (from the filed issue)
+
+- "A spec asserts... includes a `value` key matching the original
+  string" (both types) → Cycle 1/2.
+- "Existing... specs remain green" → Cycle 4.
+- "Reading back both old-shape and new-shape JSON... covered by a spec" →
+  Cycle 3.
+
+## Semver
+
+**Patch (placeholder, confirmed at Step 6 inventory)**: touches shipped
+runtime code (`lib/openehr/rm/support/identification.rb`,
+`lib/openehr/serializer/rm_json_serializer.rb`) — observable-but-corrective,
+same class as #40. No public API signature change (no new required
+argument, no removed method), no install-dependency change.

--- a/lib/openehr/rm/support/identification.rb
+++ b/lib/openehr/rm/support/identification.rb
@@ -69,6 +69,7 @@ module OpenEHR
 
           def value=(value)
             if /\A([a-zA-Z]\w+)-([a-zA-Z]\w+)-([a-zA-Z]\w+)\.([a-zA-Z]\w+)(-([a-zA-Z]\w+))?\.(v\d+)\z/ =~ value
+              @value = value
               self.rm_originator = $1
               self.rm_name = $2
               self.rm_entity = $3
@@ -171,6 +172,7 @@ module OpenEHR
 
           def value=(value)
             raise ArgumentError, "value not valid" if value.nil? or value.empty?
+            @value = value
             if /(.*)\((.*)\)/ =~ value
               self.name = $1
               self.version_id = $2

--- a/lib/openehr/serializer/rm_json_serializer.rb
+++ b/lib/openehr/serializer/rm_json_serializer.rb
@@ -24,8 +24,18 @@ module OpenEHR
         :@hour, :@minute, :@second, :@fractional_second, # DvTime, DvDateTime
         :@timezone,                                  # DvTime (String), DvDateTime (Timezone)
         :@root, :@extension,                         # UIDBasedID, HierObjectID, ObjectVersionID
-        :@oid, :@creating_system_id, :@version_tree_id # ObjectVersionID
+        :@oid, :@creating_system_id, :@version_tree_id, # ObjectVersionID
+        :@rm_originator, :@rm_name, :@rm_entity,     # ArchetypeID
+        :@concept_name, :@specialisation, :@version_id, # ArchetypeID, TerminologyID
+        :@name                                       # TerminologyID
       ].freeze
+
+      ARCHETYPE_ID_IVARS = [
+        :@rm_originator, :@rm_name, :@rm_entity,
+        :@concept_name, :@specialisation, :@version_id
+      ].freeze
+      TERMINOLOGY_ID_IVARS = [:@name, :@version_id].freeze
+      IDENTIFIER_IVARS = (ARCHETYPE_ID_IVARS + TERMINOLOGY_ID_IVARS).uniq.freeze
 
       def initialize(rm_instance)
         @rm_instance = rm_instance
@@ -55,7 +65,7 @@ module OpenEHR
 
         seen << value
         hash = {'_type' => OpenEHR::RM.type_name_of(value)}
-        (value.instance_variables - EXCLUDED_IVARS).each do |ivar|
+        (value.instance_variables - excluded_ivars(value)).each do |ivar|
           field = value.instance_variable_get(ivar)
           next if field.nil?
 
@@ -63,6 +73,18 @@ module OpenEHR
         end
         seen.delete(value)
         hash
+      end
+
+      def excluded_ivars(value)
+        exclusions = EXCLUDED_IVARS - IDENTIFIER_IVARS
+        case value
+        when OpenEHR::RM::Support::Identification::ArchetypeID
+          exclusions + ARCHETYPE_ID_IVARS
+        when OpenEHR::RM::Support::Identification::TerminologyID
+          exclusions + TERMINOLOGY_ID_IVARS
+        else
+          exclusions
+        end
       end
     end
 

--- a/spec/lib/openehr/rm/factory_spec.rb
+++ b/spec/lib/openehr/rm/factory_spec.rb
@@ -4,6 +4,27 @@ require_relative File.dirname(__FILE__) + '/../adl_parser/parser_spec_helper'
 module OpenEHR
   module RM
     describe Factory do
+      describe '.create identifier compatibility' do
+        it 'reconstructs archetype and terminology values from old and new JSON shapes' do
+          old_archetype = Factory.create(
+            'ARCHETYPE_ID',
+            rm_originator: 'openEHR', rm_name: 'EHR', rm_entity: 'SECTION',
+            concept_name: 'physical_examination', specialisation: nil, version_id: 'v2'
+          )
+          new_archetype = Factory.create(
+            'ARCHETYPE_ID', value: 'openEHR-EHR-SECTION.physical_examination.v2'
+          )
+          old_terminology = Factory.create('TERMINOLOGY_ID', name: 'SNOMED-CT', version_id: '2026')
+          new_terminology = Factory.create('TERMINOLOGY_ID', value: 'SNOMED-CT(2026)')
+
+          # regression pin: both persisted decomposed shapes and canonical value-only shapes already read correctly.
+          expect(old_archetype.value).to eq('openEHR-EHR-SECTION.physical_examination.v2')
+          expect(new_archetype.value).to eq('openEHR-EHR-SECTION.physical_examination.v2')
+          expect(old_terminology.value).to eq('SNOMED-CT(2026)')
+          expect(new_terminology.value).to eq('SNOMED-CT(2026)')
+        end
+      end
+
       describe '.params' do
         it 'converts each Hash element of an Array value into an RM object via its _type' do
           result = Factory.params(

--- a/spec/lib/openehr/serializer/rm_json_serializer_spec.rb
+++ b/spec/lib/openehr/serializer/rm_json_serializer_spec.rb
@@ -9,6 +9,25 @@ include OpenEHR::AM::Archetype::ConstraintModel
 include OpenEHR::AssumedLibraryTypes
 
 describe RMJSONSerializer do
+  # Resolution shape (a), bug: these identifiers omitted their canonical value.
+  it 'serializes the canonical value of an archetype identifier' do
+    archetype_value = 'openEHR-EHR-SECTION.physical_examination.v2'
+    archetype_id = OpenEHR::RM::Support::Identification::ArchetypeID.new(value: archetype_value)
+
+    archetype_json = JSON.parse(RMJSONSerializer.new(archetype_id).serialize)
+
+    expect(archetype_json['value']).to eq(archetype_value)
+  end
+
+  it 'serializes the canonical value of a terminology identifier' do
+    terminology_value = 'SNOMED-CT(2026)'
+    terminology_id = OpenEHR::RM::Support::Identification::TerminologyID.new(value: terminology_value)
+
+    terminology_json = JSON.parse(RMJSONSerializer.new(terminology_id).serialize)
+
+    expect(terminology_json['value']).to eq(terminology_value)
+  end
+
   it 'serializes a genuine mutual back-reference without recursing forever' do
     first = Object.new
     second = Object.new


### PR DESCRIPTION
## Summary

Fixes #46 (first reported as #45, closed as consolidated): `ArchetypeID` and `TerminologyID` (`lib/openehr/rm/support/identification.rb`) never stored their canonical `@value` ivar - their `value=` setters decompose the string into component ivars instead, so `RMJSONSerializer` never emits a `value` key for either type. Same root-cause shape as #32's `ObjectVersionID` bug (fixed by PR #39), generalized to these two sibling `ObjectID` subtypes.

Full explore + design rationale: `docs/design/fix-archetype-terminology-id-value-plan.md`.

## Fix

Both `value=` setters now store `@value = value` directly, alongside their existing decomposition (which stays - other code still needs `rm_originator`/`domain_concept`/etc.).

## Important correction found during implementation

The plan's original proposal (a flat, global `EXCLUDED_IVARS` addition, mirroring #32's exact mechanism) turned out to be **unsafe**: `:@name` and `:@version_id` collide with genuinely unrelated, legitimate ivars elsewhere - `:@name` is `Locatable#name` (a `DvText` present on nearly every RM class: `Cluster`, `Element`, `Composition`, ...), and `:@version_id` is `RevisionHistoryItem#version_id`. A naive global exclusion would have silently dropped those fields from every affected class's serialized output. Caught by the implementer (full suite failed under the naive approach) and independently re-verified by me (manually confirmed `Cluster#name` drops to `null` under the naive shape, and is correctly preserved under the fixed shape).

**Fixed mechanism**: `RMJSONSerializer#object_value` now calls a class-conditional `excluded_ivars(value)` - `ArchetypeID`'s six decomposed ivars and `TerminologyID`'s two are excluded only for instances of those specific classes, not globally.

## Tests (resolution shape: bug, per Ticket-driven workflow)

- Red → green: both identifier classes' JSON now includes `"value"` matching the original string.
- Regression pin (not staged red - this property was already true): old-shape (decomposed-only) and new-shape (`value`-only) JSON both already read back correctly via `Factory.create`, for both classes - unaffected by this fix either way.

## Compatibility

`History.txt` entry added now (merge time, per this repo's own rule). Reading back JSON persisted by a prior version of this gem is unaffected - `Factory` already reconstructs both types from their individual fields when `value` is absent.

## Related

- Fixes #46
- Related: #45 (first report, closed as consolidated), #32, PR #39 (the `ObjectVersionID` precedent this mirrors)

## Test plan
- [x] Full `bundle exec rspec` - 3973 examples, 0 failures
- [x] `bundle exec rubocop` (touched files) - no offenses
- [x] Manually verified `Cluster#name` is preserved (not collision-stripped) after the fix

## Release

Semver: patch (touches `lib/openehr/rm/support/identification.rb`, `lib/openehr/serializer/rm_json_serializer.rb`). Targets `2.4.2`; final version number confirmed at Step 6 inventory.

Implemented-by: Codex
Restructured-by: Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)